### PR TITLE
colors and transparency adjustments for vertices and edges

### DIFF
--- a/R/simplex_tree.R
+++ b/R/simplex_tree.R
@@ -464,6 +464,7 @@ plot.Rcpp_SimplexTree <- function (x, coords = NULL, vertex_opt=NULL, text_opt=N
     coords <- igraph::layout_with_fr(g)
   }
   if (missing(color_pal) || is.null(color_pal)){ color_pal <- grDevices::heat.colors(x$dimension+1, alpha = 0.20) }
+  color_pal <- alpha4sc(color_pal)
   col_n <- length(color_pal)
   graphics::plot.new()
   graphics::plot.window(xlim=range(coords[,1]), ylim=range(coords[,2]))
@@ -487,13 +488,32 @@ plot.Rcpp_SimplexTree <- function (x, coords = NULL, vertex_opt=NULL, text_opt=N
     line_coords <- apply(x$edges, 1, function(e){ t(coords[match(e, x$vertices),,drop=FALSE]) })
     p_color <- color_pal[2]
     apply(line_coords, 2, function(s){ 
-      do.call(graphics::segments, utils::modifyList(list(x0=s[1], y0=s[2], x1=s[3], y1=s[4], col=p_color), as.list(edge_opt))) 
+      do.call(graphics::segments, utils::modifyList(list(x0=s[1], y0=s[2], x1=s[3], y1=s[4], lwd=2, col=p_color), as.list(edge_opt))) 
     })
   }
   # plot vertices
   if (length(x$n_simplices) >= 1){
     do.call(graphics::points, utils::modifyList(list(x=coords, pch=21, bg=color_pal[1], cex=2), as.list(vertex_opt)))
-    do.call(graphics::text, utils::modifyList(list(x=coords,labels=as.character(x$vertices), cex=0.75), as.list(text_opt))) 
+    do.call(graphics::text, utils::modifyList(list(x=coords,labels=as.character(x$vertices), col="white", cex=0.75), as.list(text_opt))) 
   }
 }
 # .default_st_colors <- c("#FDE725CC","#F9E621CC","#F5E61FCC","#F1E51DCC","#ECE51BCC","#E8E419CC","#E4E419CC","#DFE318CC","#DBE319CC","#D7E219CC","#D2E21BCC","#CDE11DCC","#C9E020CC","#C4E022CC","#C0DF25CC","#BBDE28CC","#B7DE2ACC","#B2DD2DCC","#ADDC30CC","#A9DB33CC","#A4DB36CC","#A0DA39CC","#9BD93CCC","#96D83FCC","#92D741CC","#8ED645CC","#8AD547CC","#85D54ACC","#81D34DCC","#7DD250CC","#78D152CC","#75D054CC","#70CF57CC","#6DCD59CC","#68CD5BCC","#65CB5ECC","#61CA60CC","#5DC863CC","#59C864CC","#56C667CC","#53C569CC","#4FC46ACC","#4CC26CCC","#48C16ECC","#45BF70CC","#41BE71CC","#3FBC73CC","#3BBB75CC","#39BA76CC","#37B878CC","#34B679CC","#31B67BCC","#2FB47CCC","#2DB27DCC","#2BB07FCC","#29AF7FCC","#27AD81CC","#25AC82CC","#24AA83CC","#23A983CC","#22A785CC","#21A585CC","#20A486CC","#1FA287CC","#1FA188CC","#1F9F88CC","#1F9E89CC","#1E9C89CC","#1F9A8ACC","#1F998ACC","#1F978BCC","#1F958BCC","#20938CCC","#20928CCC","#21918CCC","#218F8DCC","#228D8DCC","#228C8DCC","#238A8DCC","#23888ECC","#24878ECC","#25858ECC","#25838ECC","#26828ECC","#26818ECC","#277F8ECC","#287D8ECC","#287C8ECC","#297A8ECC","#2A788ECC","#2A768ECC","#2B758ECC","#2C738ECC","#2C718ECC","#2D718ECC","#2E6F8ECC","#2E6D8ECC","#2F6B8ECC","#306A8ECC","#31688ECC")
+
+alpha4sc <- function(col) {
+  nc <- length(col)
+  if (nc == 0) return(col)
+  apply(
+    rbind(
+      # RGB colors
+      col2rgb(col, alpha = FALSE) / 255,
+      # alphas for each dimension
+      c(
+        if (nc > 0) .9,
+        if (nc > 1) 1,
+        if (nc > 2) rep(.2, nc - 2)
+      )
+    ),
+    2,
+    function(i) rgb(i[1], i[2], i[3], i[4])
+  )
+}

--- a/R/simplex_tree.R
+++ b/R/simplex_tree.R
@@ -468,6 +468,7 @@ plot.Rcpp_SimplexTree <- function (x, coords = NULL, vertex_opt=NULL, text_opt=N
   graphics::plot.new()
   graphics::plot.window(xlim=range(coords[,1]), ylim=range(coords[,2]))
   v <- x$vertices
+  # plot polygons for simplices of dimension 2+; omit edges and vertices
   if (length(x$n_simplices) >= 3){
     x$traverse(function(simplex){
       d <- length(simplex)
@@ -476,19 +477,22 @@ plot.Rcpp_SimplexTree <- function (x, coords = NULL, vertex_opt=NULL, text_opt=N
         ids <- apply(utils::combn(d, 3), 2, function(i){ simplex[i] })
         apply(ids, 2, function(c_id){
           idx <- match(c_id, v)
-          do.call(graphics::polygon, utils::modifyList(list(x=coords[idx,,drop=FALSE], col=p_color), as.list(polygon_opt)))
+          do.call(graphics::polygon, utils::modifyList(list(x=coords[idx,,drop=FALSE], border=NA, col=p_color), as.list(polygon_opt)))
         })
       }
     }, "dfs")
   }
+  # plot segments for edges
   if (length(x$n_simplices) >= 2){
     line_coords <- apply(x$edges, 1, function(e){ t(coords[match(e, x$vertices),,drop=FALSE]) })
+    p_color <- color_pal[2]
     apply(line_coords, 2, function(s){ 
-      do.call(graphics::segments, utils::modifyList(list(x0=s[1], y0=s[2], x1=s[3], y1=s[4]), as.list(edge_opt))) 
+      do.call(graphics::segments, utils::modifyList(list(x0=s[1], y0=s[2], x1=s[3], y1=s[4], col=p_color), as.list(edge_opt))) 
     })
   }
+  # plot vertices
   if (length(x$n_simplices) >= 1){
-    do.call(graphics::points, utils::modifyList(list(x=coords, pch=21, bg="white", cex=2), as.list(vertex_opt)))
+    do.call(graphics::points, utils::modifyList(list(x=coords, pch=21, bg=color_pal[1], cex=2), as.list(vertex_opt)))
     do.call(graphics::text, utils::modifyList(list(x=coords,labels=as.character(x$vertices), cex=0.75), as.list(text_opt))) 
   }
 }


### PR DESCRIPTION
It turns out that vertices and edges don't color well using the same transparencies that are appropriate for the simplex polygons. After some trial and error, i settled on a set of `alpha` values that seem to work well using different palettes (plus a different default `lwd` for the 1-simplices). Maybe functionality should exist to allow the user more control, but for the initial PR here's a demo of my suggested scheme with all `alpha` values reassigned using the internal function `alpha4sc()`. (Since the vertices will tend to be darker, i changed the text color to white.)

Relatedly, have you tried coloring only maximal simplices (plus the 1-skeleton), so that the color palette makes higher-dimensional simplices easier to distinguish?

[Apologies: As always, thank you for the excellent package!]

``` r
# load uninstalled branch
library(simplextree)

# example simplicial complex
stree <- simplex_tree()
stree$insert(1:3)
stree$insert(2:5)
stree$insert(5:9)
stree$insert(7:8)
stree$insert(10)
stree$print_tree()
#> 1 (h = 2): .( 2 3 )..( 3 )
#> 2 (h = 3): .( 3 4 5 )..( 4 5 5 )...( 5 )
#> 3 (h = 2): .( 4 5 )..( 5 )
#> 4 (h = 1): .( 5 )
#> 5 (h = 4): .( 6 7 8 9 )..( 7 8 9 8 9 9 )...( 8 9 9 9 )....( 9 )
#> 6 (h = 3): .( 7 8 9 )..( 8 9 9 )...( 9 )
#> 7 (h = 2): .( 8 9 )..( 9 )
#> 8 (h = 1): .( 9 )
#> 9 (h = 0): 
#> 10 (h = 0):

# plot simplicial complex
vpal <- viridis::viridis(stree$dimension + 1)
plot(stree, color_pal = vpal)
```

![](https://i.imgur.com/d1uPK62.png)

<sup>Created on 2019-08-03 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>